### PR TITLE
GameLobby Player 접속 로그 감지 추가

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -295,6 +295,7 @@ GameObject:
   m_Component:
   - component: {fileID: 243309141}
   - component: {fileID: 243309140}
+  - component: {fileID: 243309142}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -332,6 +333,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &243309142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 243309139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 912104b14299141c0ac3631f53ce19f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &330585543
 GameObject:
   m_ObjectHideFlags: 0
@@ -8417,6 +8430,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ui: {fileID: 1210555085}
+  roommanager: {fileID: 243309142}
 --- !u!114 &8503033929994636733
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Process/GameManager.cs
+++ b/Assets/Scripts/Process/GameManager.cs
@@ -10,12 +10,12 @@ public class GameManager : MonoBehaviour
 
     private void OnEnable()
     {
-        planeManager.OnCompletedPlaneSetting += OnCompletedPlane;
+       // planeManager.OnCompletedPlaneSetting += OnCompletedPlane;
     }
 
     private void OnDisable()
     {
-        planeManager.OnCompletedPlaneSetting -= OnCompletedPlane;
+      //  planeManager.OnCompletedPlaneSetting -= OnCompletedPlane;
     }
 
     private void OnCompletedPlane()

--- a/Assets/Scripts/Process/GameRoomManager.cs
+++ b/Assets/Scripts/Process/GameRoomManager.cs
@@ -13,8 +13,10 @@ public class GameRoomManager : MonoBehaviour
     public Action<Player, string, string> OnChangedPlayerState = null;
     public Action<string> OnChangedHost = null;
     public Action<string, string> OnLobbyStateChaged = null;
+
+    private GameLobby gameLobby;
     
-    void Start()
+    private void Start()
     {
         CheckRoomHost();
         SubscribeToLobbyChanges();
@@ -41,6 +43,8 @@ public class GameRoomManager : MonoBehaviour
             yield return new WaitForSeconds(15);
         }
     }
+    private LobbyEventCallbacks _callbacks;
+    private bool _isSubscribed = false;
     
     private string lastKnownHostId;
 
@@ -67,11 +71,11 @@ public class GameRoomManager : MonoBehaviour
                 lastKnownHostId = lobby.HostId.Value;
             }
             
-            if (lobby.PlayerJoined.Changed)
+            if (lobby.PlayerJoined.Added)
             {
                 foreach (LobbyPlayerJoined joinedPlayer in lobby.PlayerJoined.Value)
                 {
-                    Debug.Log($"플레이어 추가됨: {joinedPlayer.Player.Profile.Name}");
+                    Debug.Log($"플레이어 추가됨: {joinedPlayer.Player.Data["nickname"].Value}");
                     OnEnteredPlayer?.Invoke(joinedPlayer.Player);
                 }
             }

--- a/Assets/Scripts/Room/PlayerListContoller.cs
+++ b/Assets/Scripts/Room/PlayerListContoller.cs
@@ -3,20 +3,26 @@ using UnityEngine;
 public class PlayerListContoller : MonoBehaviour
 {
     [SerializeField] private PlayerListUI ui;
+    [SerializeField] private GameRoomManager roommanager;
     private PlayerListModel model = new PlayerListModel();
 
     private void Start()
     {
         model.OnUpdatePlayerList(PlayerSession.Instance.CurrentLobby);
+        OnEnable();
     }
     
     private void OnEnable()
     {
+        roommanager.OnEnteredPlayer += model.OnAddPlayer;
         model.UpdateListUI += ui.UpdateUI;
+        model.AddListUI += ui.AddListUI;
     }
 
     private void OnDisable()
     {
+        roommanager.OnEnteredPlayer -= model.OnAddPlayer;
         model.UpdateListUI -= ui.UpdateUI;
+        model.AddListUI -= ui.AddListUI;
     }
 }

--- a/Assets/Scripts/Room/PlayerListModel.cs
+++ b/Assets/Scripts/Room/PlayerListModel.cs
@@ -6,14 +6,19 @@ using UnityEngine;
 public class PlayerListModel
 {
     public event Action<List<Player>> UpdateListUI;
+    public event Action<Player> AddListUI;
     
     private List<Player> players;
-
 
     public void OnUpdatePlayerList(Lobby lobby)
     {
         Debug.Log("PlayerList Model Update");
         players = lobby.Players;
         UpdateListUI?.Invoke(players);
+    }
+
+    public void OnAddPlayer(Player player)
+    {
+        AddListUI?.Invoke(player);
     }
 }

--- a/Assets/Scripts/Room/PlayerListUI.cs
+++ b/Assets/Scripts/Room/PlayerListUI.cs
@@ -23,7 +23,7 @@ public class PlayerListUI : MonoBehaviour
     public void UpdateUI(List<Player> players)
     {
         ClearList();
-Debug.Log("플레이어 리스트 업데이트");
+
         foreach (Player player in players)
         {
             PlayerDataItem newItem = GetItem();
@@ -35,6 +35,18 @@ Debug.Log("플레이어 리스트 업데이트");
             Debug.Log($"플레이어 ID: {player.Id}, 닉네임: {nickname}");
             newItem.SetPlayerItem(nickname);
         }
+    }
+
+    public void AddListUI(Player player)
+    {
+        PlayerDataItem newItem = GetItem();
+            
+        string nickname = player.Data != null && player.Data.ContainsKey("nickname")
+            ? player.Data["nickname"].Value
+            : "(이름 없음)";
+    
+        Debug.Log($"플레이어 ID: {player.Id}, 닉네임: {nickname}");
+        newItem.SetPlayerItem(nickname);
     }
 
     private PlayerDataItem GetItem()


### PR DESCRIPTION
#1 

작업내용
 - Lobby Player 접속 감지 이벤트 로그 추가
 - LobbyEventCallbacks.PlayerJoined 이벤트 동작 X
 - LobbyEventCallbacks.LobbyChanged의 PlayerJoined 확인 및 해당 이벤트 로그 추가

후속 작업 필요사항
 - LocalLobby 관리 스크립트 추가(Main Lobby와 Game Lobby 공용으로 사용할 수 있는 구조. static X)
 - Game Lobby EventCallback 추가 및 기능 모듈화