### PR TITLE
BombOwner 설정 및 최대 개수만 사용 로직 추가

### DIFF
--- a/Assets/Scripts/Bomb/WaterBomb.cs
+++ b/Assets/Scripts/Bomb/WaterBomb.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class WaterBomb : NetworkBehaviour
 {
     public event Action<Vector3, Vector3> OnExplodeDirectionAction;
+    public event Action<string> ExplodeBomb;
     [SerializeField] private Collider collider;
     
     private int objIndex;
@@ -20,6 +21,7 @@ public class WaterBomb : NetworkBehaviour
     private Collider playerCollider;
 
     private bool isSet = false;
+    public bool IsSet => isSet;
     private bool explode = false;
     
     private void Start()
@@ -45,14 +47,14 @@ public class WaterBomb : NetworkBehaviour
         }
     }
 
-    public void SetBomb(int power, string bombOwner)
+    public void SetBomb(int power, string bombowner)
     {
         if (isSet)
             return;
 
         isSet = false;
         collider.isTrigger = true;
-        bombOwner = bombOwner;
+        bombOwner = bombowner;
         gameObject.SetActive(true);
         explosionRange = power;
         StartCoroutine(WaitExplode());
@@ -72,6 +74,7 @@ public class WaterBomb : NetworkBehaviour
         CheckDirection(Vector3.forward, origin, explosionRange);
         CheckDirection(Vector3.back, origin, explosionRange);
         
+        ExplodeBomb?.Invoke(bombOwner);
         BombReset();
     }
 
@@ -87,6 +90,7 @@ public class WaterBomb : NetworkBehaviour
     {
         isSet = false;
         explode = false;
+        bombOwner = string.Empty;
         gameObject.SetActive(false);
     }
 

--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -89,7 +89,14 @@ public class PlayerManager : NetworkBehaviour, IPlayerBuff, IPlayer
         {
             PlaneParts plane = hit.collider.gameObject.GetComponent<PlaneParts>();
             plane?.SetBombServerRpc(stat.GetPlayerPower, playerid);
+            plane.explodeBomb = OnExplodeBomb;
         }
+    }
+
+    private void OnExplodeBomb(string owner)
+    {
+        if(owner.Equals(playerid))
+            stat.UseBombStat(false);
     }
 
     public void TakeDamage()


### PR DESCRIPTION
#28 

 - Water Bomb 사용자별 playerInfo 제어로 개수 생성 제한 적용
 - 생성은 rpc 동기화 bomb owner에 따른 playerInfo 데이터 사용은 local로 작동

다음 작업
 - player ready완료시 player spawn